### PR TITLE
Fix the link to open the notebook in colab

### DIFF
--- a/Fundamentals/elementary_notions/amdahls_law.ipynb
+++ b/Fundamentals/elementary_notions/amdahls_law.ipynb
@@ -21,7 +21,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/rkurniawati/ToUCHmodules/blob/master/Fundamentals/elementary_notions/Amdahl's_Law.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/TeachingUndergradsCHC/modules/blob/master/Fundamentals/elementary_notions/amdahls_law.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
A small change to fix the link to open the notebook in colab -- old link was pointing to the wrong repo and also wrong notebook name.

Thanks,
Ruth